### PR TITLE
feat: search API operations tool

### DIFF
--- a/typescript/src/shared/tools/index.ts
+++ b/typescript/src/shared/tools/index.ts
@@ -13,6 +13,7 @@ import { getServicesList } from '@/shared/tools/services/getServicesList';
 // Operations tools
 import { getApiOperationList } from '@/shared/tools/operations/getApiOperationList';
 import { getApiOperationDetails } from '@/shared/tools/operations/getApiOperationDetails';
+import { searchApiOperations } from '@/shared/tools/operations/searchApiOperations';
 
 export const tools = (context: ToolContext): Tool[] => [
   // Services
@@ -28,4 +29,5 @@ export const tools = (context: ToolContext): Tool[] => [
   // API Operations
   getApiOperationList(context),
   getApiOperationDetails(context),
+  searchApiOperations(context),
 ];

--- a/typescript/src/shared/tools/operations/__tests__/searchApiOperations.test.ts
+++ b/typescript/src/shared/tools/operations/__tests__/searchApiOperations.test.ts
@@ -1,0 +1,95 @@
+import {
+  execute,
+  getParameters,
+} from '@/shared/tools/operations/searchApiOperations';
+import api from '@/shared/api';
+
+// Mock the API module so tests can control the responses from
+// getApiOperations without performing network requests.
+jest.mock<typeof api>('@/shared/api');
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+describe('execute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should filter operations based on query', async () => {
+    // Sample operations returned by the mocked API.
+    const operations = [
+      {
+        summary: 'Get payment',
+        description: 'Retrieve payment',
+        tags: ['Payments'],
+      },
+      {
+        summary: 'List accounts',
+        description: 'Retrieve accounts',
+        tags: ['Accounts', 'Finance'],
+      },
+    ];
+    mockApi.getApiOperations.mockResolvedValue(JSON.stringify({ operations }));
+
+    // Execute the tool with a search query that matches the first operation.
+    const result = await execute(
+      {},
+      { apiSpecificationPath: '/spec.yaml', query: 'payment' }
+    );
+
+    expect(mockApi.getApiOperations).toHaveBeenCalledWith('/spec.yaml');
+    // Only the operation matching the query should be returned.
+    expect(JSON.parse(result)).toEqual([operations[0]]);
+  });
+
+  it('should filter operations based on query and tag with context path', async () => {
+    // Same operations as above but the search also filters by tag.
+    const operations = [
+      {
+        summary: 'Get payment',
+        description: 'Retrieve payment',
+        tags: ['Payments'],
+      },
+      {
+        summary: 'List accounts',
+        description: 'Retrieve accounts',
+        tags: ['Accounts', 'Finance'],
+      },
+    ];
+    mockApi.getApiOperations.mockResolvedValue(JSON.stringify({ operations }));
+
+    // The context already supplies the spec path, so only query and tag are
+    // passed in.
+    const result = await execute(
+      { apiSpecificationPath: '/context.yaml' },
+      { query: 'account', tag: 'Finance' }
+    );
+
+    expect(mockApi.getApiOperations).toHaveBeenCalledWith('/context.yaml');
+    // The second operation matches both the query and the tag.
+    expect(JSON.parse(result)).toEqual([operations[1]]);
+  });
+});
+
+describe('getParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    // When no spec path is provided in the context the schema should include
+    // apiSpecificationPath in addition to query and tag.
+    const parameters = getParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['apiSpecificationPath', 'query', 'tag']);
+    expect(fields.length).toBe(3);
+  });
+
+  it('should return the correct parameters if apiSpecificationPath is specified in context', () => {
+    // With an existing spec path in the context only query and tag are needed.
+    const parameters = getParameters({
+      apiSpecificationPath: '/test/path.yaml',
+    });
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['query', 'tag']);
+    expect(fields.length).toBe(2);
+  });
+});

--- a/typescript/src/shared/tools/operations/searchApiOperations.ts
+++ b/typescript/src/shared/tools/operations/searchApiOperations.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { Tool, ToolContext } from '@/shared/types';
+import api from '@/shared/api';
+
+// Minimal shape describing an API operation. Only the fields that are
+// relevant for searching are modeled here.
+type ApiOperation = {
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  [key: string]: any;
+};
+
+// Build the description shown to tool consumers. The description differs
+// depending on whether the specification path is supplied in the context or
+// must be provided by the caller.
+const getDescription = (context: ToolContext): string => {
+  const baseDescription = `Searches API operations within a specification by keyword and optional tag, filtering by matches in summary, description, or tags.`;
+
+  if (context.apiSpecificationPath) {
+    // When the path is predefined in the context we only expose query and tag
+    // parameters to the user.
+    return `${baseDescription}\n\nUses the configured API specification: ${context.apiSpecificationPath}\n\nIt takes two arguments:\n- query (str): The search query to match against operation summary, description, or tags\n- tag (str, optional): A tag name to filter operations`;
+  }
+
+  // Otherwise the caller must provide the specification path in addition to
+  // the search criteria.
+  return `${baseDescription}\n\nIt takes three arguments:\n- apiSpecificationPath (str): The path to the API specification file (e.g., /open-banking-us/swagger/openbanking-us.yaml)\n- query (str): The search query to match against operation summary, description, or tags\n- tag (str, optional): A tag name to filter operations`;
+};
+
+// Construct a Zod schema describing the tool parameters. If the
+// specification path is already supplied in the context we omit it from the
+// required parameters.
+export const getParameters = (context: ToolContext): z.ZodObject<any> => {
+  const baseParams = {
+    // Free text to match against summary, description or tags.
+    query: z
+      .string()
+      .describe(
+        'The search query to match against operation summary, description, or tags'
+      ),
+    // Optional tag to further narrow down the results.
+    tag: z.string().optional().describe('A tag name to filter operations'),
+  };
+
+  if (context.apiSpecificationPath) {
+    // No need to request the spec path again if it is already configured.
+    return z.object(baseParams);
+  }
+
+  // Otherwise include the spec path parameter so the tool knows which spec to
+  // read.
+  return z.object({
+    apiSpecificationPath: z
+      .string()
+      .describe(
+        'The path to the API specification file (e.g., /open-banking-us/swagger/openbanking-us.yaml)'
+      ),
+    ...baseParams,
+  });
+};
+
+// Execute the search. Operations are fetched from the API and then filtered
+// locally based on the provided search query and optional tag.
+export const execute = async (
+  context: ToolContext,
+  params: z.infer<ReturnType<typeof getParameters>>
+): Promise<string> => {
+  // Determine the path to the specification from the context or parameters.
+  const apiSpecificationPath =
+    context.apiSpecificationPath ?? params.apiSpecificationPath;
+
+  // Retrieve the list of operations from the API service.
+  const response = await api.getApiOperations(apiSpecificationPath);
+  let parsed: any;
+  try {
+    // The API returns JSON by convention. If parsing fails, forward the raw
+    // response so callers can inspect the error.
+    parsed = JSON.parse(response);
+  } catch {
+    return response;
+  }
+
+  // Normalize the operations into an array regardless of whether the payload
+  // is wrapped in an { operations } object or is already an array.
+  const operations: ApiOperation[] = Array.isArray(parsed.operations)
+    ? parsed.operations
+    : Array.isArray(parsed)
+      ? parsed
+      : [];
+
+  // Prepare the search criteria in lowercase for case-insensitive matching.
+  const query = params.query.toLowerCase();
+  const tag = params.tag?.toLowerCase();
+
+  const filtered = operations.filter((op) => {
+    // Coerce values to strings and lowercase to simplify searching.
+    const summary = (op.summary ?? '').toLowerCase();
+    const description = (op.description ?? '').toLowerCase();
+    const tags = Array.isArray(op.tags)
+      ? op.tags.map((t) => t.toLowerCase())
+      : [];
+
+    // A match occurs if the query is found in any of the searchable fields.
+    const matchesQuery =
+      summary.includes(query) ||
+      description.includes(query) ||
+      tags.some((t) => t.includes(query));
+
+    // If a tag was specified, ensure the operation contains it.
+    const matchesTag = tag ? tags.includes(tag) : true;
+
+    return matchesQuery && matchesTag;
+  });
+
+  // Return the matching operations as pretty-printed JSON so the caller can
+  // inspect them directly.
+  return JSON.stringify(filtered, null, 2);
+};
+
+// Factory that exposes the tool in a format understood by the runtime.
+export const searchApiOperations = (context: ToolContext): Tool => ({
+  method: 'search-api-operations',
+  name: 'Search API Operations',
+  description: getDescription(context),
+  parameters: getParameters(context),
+  execute: (params) => execute(context, params),
+});


### PR DESCRIPTION
## Summary
- add tool to search API operations by query and optional tag
- register tool alongside existing operations tools
- test keyword and tag-based searches
- clarify logic with explanatory comments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e3637e2e48324ae651afc660dcf61